### PR TITLE
Added option to include page body in crawl results

### DIFF
--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -77,9 +77,9 @@ def test_url_regex() -> None:
         content_type="text/html",
     )
 
-    # This regex matches strings starting with "http://example.com/" 
+    # This regex matches strings starting with "http://example.com/"
     # And only have numeric characters after it
-    regex = r"http://example\.com/[0-9]+" 
+    regex = r"http://example\.com/[0-9]+"
 
     spider = Spider("http://example.com", 0, url_regex=regex)
     spider.start()
@@ -87,6 +87,37 @@ def test_url_regex() -> None:
     assert spider.crawl_result["http://example.com"]["urls"] == ["http://example.com/123"]
 
     assert "http://example.com/test" not in spider.crawl_result["http://example.com"]["urls"]
+
+
+@responses.activate
+def test_include_body() -> None:
+    # Mock HTTP response
+    responses.add(
+        responses.GET,
+        "http://example.com",
+        body="<html><body><a href='http://example.com/test'>link</a></body></html>",
+        status=200,
+        content_type="text/html",
+    )
+    responses.add(
+        responses.GET,
+        "http://example.com/test",
+        body="<html><body><h>This is a header</h></body></html>",
+        status=200,
+        content_type="text/html",
+    )
+
+    spider = Spider("http://example.com", include_body=True)
+    spider.start()
+
+    assert (
+        spider.crawl_result["http://example.com"]["body"]
+        == '<html><body><a href="http://example.com/test">link</a></body></html>'
+    )
+    assert (
+        spider.crawl_result["http://example.com/test"]["body"]
+        == "<html><body><h>This is a header</h></body></html>"
+)
 
 
 @patch.object(Spider, "crawl")

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -117,7 +117,7 @@ def test_include_body() -> None:
     assert (
         spider.crawl_result["http://example.com/test"]["body"]
         == "<html><body><h>This is a header</h></body></html>"
-)
+    )
 
 
 @patch.object(Spider, "crawl")

--- a/tiny_web_crawler/crawler.py
+++ b/tiny_web_crawler/crawler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import json
 import urllib.parse
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Union
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import time
@@ -40,7 +40,7 @@ class Spider():
     max_workers: int = 1
     delay: float = 0.5
     verbose: bool = True
-    crawl_result: Dict[str, Dict[str, List[str]]] = field(default_factory=dict)
+    crawl_result: Dict[str, Dict[str, Union[List[str], str]]] = field(default_factory=dict)
     crawl_set: Set[str] = field(default_factory=set)
     link_count: int = 0
     scheme: str = field(default=DEFAULT_SCHEME, init=False)

--- a/tiny_web_crawler/crawler.py
+++ b/tiny_web_crawler/crawler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import json
 import urllib.parse
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Set, NotRequired, TypedDict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import time
@@ -40,7 +40,7 @@ class Spider():
     max_workers: int = 1
     delay: float = 0.5
     verbose: bool = True
-    crawl_result: Dict[str, Dict[str, Union[List[str], str]]] = field(default_factory=dict)
+    crawl_result: Dict[str, Dict[str, List[str]]] = field(default_factory=dict)
     crawl_set: Set[str] = field(default_factory=set)
     link_count: int = 0
     scheme: str = field(default=DEFAULT_SCHEME, init=False)
@@ -149,7 +149,7 @@ class Spider():
         self.crawl_result[url] = {'urls': []}
 
         if self.include_body:
-            self.crawl_result[url]['body'] = str(soup.html)
+            self.crawl_result[url]['body'] = str(soup)
 
         for link in links:
             pretty_url = self.format_url(link['href'].lstrip(), url)

--- a/tiny_web_crawler/crawler.py
+++ b/tiny_web_crawler/crawler.py
@@ -24,7 +24,7 @@ class Spider():
     Attributes:
         root_url (str): The root URL to start crawling from.
         max_links (int): The maximum number of links to crawl.
-        crawl_result (Dict[str, Dict[str, List[str]]]): The dictionary storing the crawl results.
+        crawl_result (Dict[str, Dict[str, Any]): The dictionary storing the crawl results.
         crawl_set (Set[str]): A set of URLs to be crawled.
         link_count (int): The current count of crawled links.
         save_to_file (Optional[str]): The file path to save the crawl results.
@@ -40,7 +40,7 @@ class Spider():
     max_workers: int = 1
     delay: float = 0.5
     verbose: bool = True
-    crawl_result: Dict[str, Any] = field(default_factory=dict)
+    crawl_result: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     crawl_set: Set[str] = field(default_factory=set)
     link_count: int = 0
     scheme: str = field(default=DEFAULT_SCHEME, init=False)

--- a/tiny_web_crawler/crawler.py
+++ b/tiny_web_crawler/crawler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import json
 import urllib.parse
-from typing import Dict, List, Optional, Set, NotRequired, TypedDict
+from typing import Dict, List, Optional, Set, Any
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import time
@@ -40,7 +40,7 @@ class Spider():
     max_workers: int = 1
     delay: float = 0.5
     verbose: bool = True
-    crawl_result: Dict[str, Dict[str, List[str]]] = field(default_factory=dict)
+    crawl_result: Dict[str, Any] = field(default_factory=dict)
     crawl_set: Set[str] = field(default_factory=set)
     link_count: int = 0
     scheme: str = field(default=DEFAULT_SCHEME, init=False)

--- a/tiny_web_crawler/crawler.py
+++ b/tiny_web_crawler/crawler.py
@@ -31,6 +31,7 @@ class Spider():
         max_workers (int): Max count of concurrent workers
         delay (float): request delay
         url_regex (Optional[str]): A regular expression against which urls will be matched before crawling
+        include_body (bool): Whether or not to include the crawled page's body in crawl_result (default: False)
     """
 
     root_url: str
@@ -44,6 +45,7 @@ class Spider():
     link_count: int = 0
     scheme: str = field(default=DEFAULT_SCHEME, init=False)
     url_regex: Optional[str] = None
+    include_body: bool = False
 
     def fetch_url(self, url: str) -> Optional[BeautifulSoup]:
         """
@@ -145,6 +147,9 @@ class Spider():
 
         links = soup.body.find_all('a', href=True) if soup.body else []
         self.crawl_result[url] = {'urls': []}
+
+        if self.include_body:
+            self.crawl_result[url]['body'] = str(soup.html)
 
         for link in links:
             pretty_url = self.format_url(link['href'].lstrip(), url)


### PR DESCRIPTION
Closes #8 

**Changes**
- Added `include_body` argument in the `Spider` class. This is a boolean that defaults to false. When set to true, the body of the crawled pages will be included in `crawl_result`.
- In `Spider.crawl` added the code to add the body to `crawl_result` from `soup.html`.
- Added a test for this feature.

Right now the body of the page is added regardless of wether it finds links inside it or not! This just felt like the most expectable behavior, but let me know if I should change it. 
Also there are no verbose prints, I didn't find it necessary but let me know if I should add some 👍 