### PR TITLE
Add mypy and pytest to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [commit]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.10.0'
+    hooks:
+      - id: mypy
+        args: [--install-types, --non-interactive]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,6 @@ repos:
         name: Run pytest
         entry: poetry run pytest
         language: system
-        types: [python]
-        stages: [push]
+        pass_filenames: false
+        always_run: true
+        stages: [commit]


### PR DESCRIPTION
Closes #20 

**Changes**
- Run tests with `poetry run pytest` on commit;
  - I set this to run regardless of whether a .py file is staged, just for safety, but let me know if I should change this.
- Run mypy type checks on commit;