### PR TITLE
Set tests stage to push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-        stages: [commit]
+        stages: [push]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.10.0'
     hooks:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Before starting to work on an issue. Please get it assigned to you so that we ca
 - Clone the repo
 - Create a venv or use `poetry shell`
 - Run `poetry install --with dev`
+- `pre-commit install` ([see](https://github.com/indrajithi/tiny-web-crawler/issues/23))
+- `pre-commit install --hook-type pre-push`
 
 Before raising a PR. Please make sure you have these checks covered
 


### PR DESCRIPTION
Closes #20

**Changes**
Set the pytest stage to run on push rather than on commit.
For this to work, the push hook has to be installed through `pre-commit install --hook-type pre-push`
Also added the command to install the push hook to the Contribute part of the README