### PR TITLE
Coverage report in readme

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           path: .coverage.${{ matrix.python-version }}
 
   coverage-comment:
+    name: Create coverage comment
     needs: test
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install Poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    env:
+      COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -45,6 +49,35 @@ jobs:
       - name: Run tests
         run: |
           poetry run pytest --cov=./
+      - name: Store coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: .coverage.${{ matrix.python-version }}
+          path: .coverage.${{ matrix.python-version }}
+
+  coverage-comment:
+    needs: test
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        name: Retrieve coverage files
+        id: download
+        with:
+          pattern: .coverage.*
+          merge-multiple: true
+
+      - uses: py-cov-action/python-coverage-comment-action@v3.24
+        name: Generate coverage comment
+        id: coverage_comment
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_COVERAGE_FILES: true
 
   publish:
     needs: test


### PR DESCRIPTION
Closes #30

**Changes**
Changed the ci workflow to use the [py-cov-action/python-coverage-comment-action](https://github.com/py-cov-action/python-coverage-comment-action/tree/v3.24/) to create a coverage badge and report to display in the readme.
To do this, I also had to add a `.coveragerc` file to store a configuration option for pytest-cov.

Also I took the liberty to upgrade `actions/setup-python` from version 3 to version 5 :)