### PR TITLE
Add `internal_links_only` and `external_links_only` options

### DIFF
--- a/src/tiny_web_crawler/core/spider.py
+++ b/src/tiny_web_crawler/core/spider.py
@@ -46,13 +46,14 @@ class Spider:
     crawl_result: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     crawl_set: Set[str] = field(default_factory=set)
     link_count: int = 0
-    scheme: str = field(default=DEFAULT_SCHEME, init=False)
     url_regex: Optional[str] = None
     include_body: bool = False
     internal_links_only: bool = False
     external_links_only: bool = False
 
     def __post_init__(self) -> None:
+        self.scheme = DEFAULT_SCHEME
+
         self.root_netloc = urllib.parse.urlparse(self.root_url).netloc
 
         if self.internal_links_only and self.external_links_only:

--- a/src/tiny_web_crawler/core/spider.py
+++ b/src/tiny_web_crawler/core/spider.py
@@ -7,6 +7,7 @@ import re
 
 from typing import Dict, List, Optional, Set, Any
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import urllib.parse
 from colorama import Fore, Style
 
 from tiny_web_crawler.networking.fetcher import fetch_url
@@ -31,9 +32,12 @@ class Spider:
         delay (float): request delay
         url_regex (Optional[str]): A regular expression against which urls will be matched before crawling
         include_body (bool): Whether or not to include the crawled page's body in crawl_result (default: False)
+        internal_links_only (bool): Whether or not to crawl only internal links
+        external_links_only (bool): Whether or not to crawl only external links
     """
 
     root_url: str
+    root_netloc: str = field(init=False)
     max_links: int = 5
     save_to_file: Optional[str] = None
     max_workers: int = 1
@@ -45,6 +49,11 @@ class Spider:
     scheme: str = field(default=DEFAULT_SCHEME, init=False)
     url_regex: Optional[str] = None
     include_body: bool = False
+    internal_links_only: bool = False
+    external_links_only: bool = False
+
+    def __post_init__(self) -> None:
+        self.root_netloc = urllib.parse.urlparse(self.root_url).netloc
 
     def verbose_print(self, content: str) -> None:
         if self.verbose:
@@ -97,6 +106,14 @@ class Spider:
                 if not re.compile(self.url_regex).match(pretty_url):
                     self.verbose_print(Fore.YELLOW + f"Skipping: URL didn't match regex: {pretty_url}")
                     continue
+
+            if self.internal_links_only and self.root_netloc != urllib.parse.urlparse(pretty_url).netloc:
+                self.verbose_print(Fore.RED + f"Skipping: External link: {pretty_url}")
+                continue
+
+            if self.external_links_only and self.root_netloc == urllib.parse.urlparse(pretty_url).netloc:
+                self.verbose_print(Fore.RED + f"Skipping: Internal link: {pretty_url}")
+                continue
 
             self.crawl_result[url]['urls'].append(pretty_url)
             self.crawl_set.add(pretty_url)

--- a/src/tiny_web_crawler/core/spider.py
+++ b/src/tiny_web_crawler/core/spider.py
@@ -55,6 +55,9 @@ class Spider:
     def __post_init__(self) -> None:
         self.root_netloc = urllib.parse.urlparse(self.root_url).netloc
 
+        if self.internal_links_only and self.external_links_only:
+            raise ValueError("Only one of internal_links_only and external_links_only can be set to True")
+
     def verbose_print(self, content: str) -> None:
         if self.verbose:
             print(content)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import responses
 
+import pytest
+
 from tiny_web_crawler.core.spider import Spider
 from tests.utils import setup_mock_response
 
@@ -218,6 +220,12 @@ def test_external_links_only(capsys) -> None: # type: ignore
     captured = capsys.readouterr()
     assert "Skipping: Internal link:" in captured.out
     assert spider.crawl_result == {"http://internal.com": {"urls": ["http://external.com/test"]}}
+
+
+@responses.activate
+def test_external_and_internal_links_only() -> None:
+    with pytest.raises(ValueError):
+        Spider("http://example.com", external_links_only=True, internal_links_only=True)
 
 
 @patch.object(Spider, "crawl")


### PR DESCRIPTION
Closes #11 

**Changes**
Added `internal_links_only` and `external_links_only` options to skip links that match or dont match the root url netloc.
Also added two test cases for these two options.