### PR TITLE
Feature: Logging

### DIFF
--- a/src/tiny_web_crawler/core/spider.py
+++ b/src/tiny_web_crawler/core/spider.py
@@ -13,8 +13,10 @@ from colorama import Fore, Style
 from tiny_web_crawler.networking.fetcher import fetch_url
 from tiny_web_crawler.networking.validator import is_valid_url
 from tiny_web_crawler.networking.formatter import format_url
+from tiny_web_crawler.logging import get_logger, set_logging_level, INFO, DEBUG
 
 DEFAULT_SCHEME: str = 'http://'
+logger = get_logger()
 
 @dataclass
 class Spider:
@@ -59,9 +61,10 @@ class Spider:
         if self.internal_links_only and self.external_links_only:
             raise ValueError("Only one of internal_links_only and external_links_only can be set to True")
 
-    def verbose_print(self, content: str) -> None:
         if self.verbose:
-            print(content)
+            set_logging_level(DEBUG)
+        else:
+            set_logging_level(INFO)
 
     def save_results(self) -> None:
         """
@@ -79,14 +82,14 @@ class Spider:
             url (str): The URL to crawl.
         """
         if not is_valid_url(url):
-            self.verbose_print(Fore.RED + f"Invalid url to crawl: {url}")
+            logger.debug(Fore.RED + f"Invalid url to crawl: {url}")
             return
 
         if url in self.crawl_result:
-            self.verbose_print(Fore.YELLOW + f"URL already crawled: {url}")
+            logger.debug(Fore.YELLOW + f"URL already crawled: {url}")
             return
 
-        self.verbose_print(Fore.GREEN + f"Crawling: {url}")
+        logger.debug(Fore.GREEN + f"Crawling: {url}")
         soup = fetch_url(url)
         if not soup:
             return
@@ -100,7 +103,7 @@ class Spider:
         for link in links:
             pretty_url = format_url(link['href'].lstrip(), url, self.scheme)
             if not is_valid_url(pretty_url):
-                self.verbose_print(Fore.RED + f"Invalid url: {pretty_url}")
+                logger.debug(Fore.RED + f"Invalid url: {pretty_url}")
                 continue
 
             if pretty_url in self.crawl_result[url]['urls']:
@@ -108,24 +111,24 @@ class Spider:
 
             if self.url_regex:
                 if not re.compile(self.url_regex).match(pretty_url):
-                    self.verbose_print(Fore.YELLOW + f"Skipping: URL didn't match regex: {pretty_url}")
+                    logger.debug(Fore.YELLOW + f"Skipping: URL didn't match regex: {pretty_url}")
                     continue
 
             if self.internal_links_only and self.root_netloc != urllib.parse.urlparse(pretty_url).netloc:
-                self.verbose_print(Fore.RED + f"Skipping: External link: {pretty_url}")
+                logger.debug(Fore.RED + f"Skipping: External link: {pretty_url}")
                 continue
 
             if self.external_links_only and self.root_netloc == urllib.parse.urlparse(pretty_url).netloc:
-                self.verbose_print(Fore.RED + f"Skipping: Internal link: {pretty_url}")
+                logger.debug(Fore.RED + f"Skipping: Internal link: {pretty_url}")
                 continue
 
             self.crawl_result[url]['urls'].append(pretty_url)
             self.crawl_set.add(pretty_url)
-            self.verbose_print(Fore.BLUE + f"Link found: {pretty_url}")
+            logger.debug(Fore.BLUE + f"Link found: {pretty_url}")
 
         if self.link_count < self.max_links:
             self.link_count += 1
-            self.verbose_print(Fore.GREEN + f"Links crawled: {self.link_count}")
+            logger.debug(Fore.GREEN + f"Links crawled: {self.link_count}")
 
     def start(self) -> Dict[str, Dict[str, List[str]]]:
         """
@@ -150,5 +153,5 @@ class Spider:
 
         if self.save_to_file:
             self.save_results()
-        self.verbose_print(Style.BRIGHT + Fore.MAGENTA + "Exiting....")
+        logger.debug("%s%sExiting....", Style.BRIGHT, Fore.MAGENTA)
         return self.crawl_result

--- a/src/tiny_web_crawler/core/spider.py
+++ b/src/tiny_web_crawler/core/spider.py
@@ -8,7 +8,6 @@ import re
 from typing import Dict, List, Optional, Set, Any
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import urllib.parse
-from colorama import Fore, Style
 
 from tiny_web_crawler.networking.fetcher import fetch_url
 from tiny_web_crawler.networking.validator import is_valid_url
@@ -82,14 +81,14 @@ class Spider:
             url (str): The URL to crawl.
         """
         if not is_valid_url(url):
-            logger.debug(Fore.RED + f"Invalid url to crawl: {url}")
+            logger.debug(f"Invalid url to crawl: {url}")
             return
 
         if url in self.crawl_result:
-            logger.debug(Fore.YELLOW + f"URL already crawled: {url}")
+            logger.debug(f"URL already crawled: {url}")
             return
 
-        logger.debug(Fore.GREEN + f"Crawling: {url}")
+        logger.debug(f"Crawling: {url}")
         soup = fetch_url(url)
         if not soup:
             return
@@ -103,7 +102,7 @@ class Spider:
         for link in links:
             pretty_url = format_url(link['href'].lstrip(), url, self.scheme)
             if not is_valid_url(pretty_url):
-                logger.debug(Fore.RED + f"Invalid url: {pretty_url}")
+                logger.debug(f"Invalid url: {pretty_url}")
                 continue
 
             if pretty_url in self.crawl_result[url]['urls']:
@@ -111,24 +110,24 @@ class Spider:
 
             if self.url_regex:
                 if not re.compile(self.url_regex).match(pretty_url):
-                    logger.debug(Fore.YELLOW + f"Skipping: URL didn't match regex: {pretty_url}")
+                    logger.debug(f"Skipping: URL didn't match regex: {pretty_url}")
                     continue
 
             if self.internal_links_only and self.root_netloc != urllib.parse.urlparse(pretty_url).netloc:
-                logger.debug(Fore.RED + f"Skipping: External link: {pretty_url}")
+                logger.debug(f"Skipping: External link: {pretty_url}")
                 continue
 
             if self.external_links_only and self.root_netloc == urllib.parse.urlparse(pretty_url).netloc:
-                logger.debug(Fore.RED + f"Skipping: Internal link: {pretty_url}")
+                logger.debug(f"Skipping: Internal link: {pretty_url}")
                 continue
 
             self.crawl_result[url]['urls'].append(pretty_url)
             self.crawl_set.add(pretty_url)
-            logger.debug(Fore.BLUE + f"Link found: {pretty_url}")
+            logger.debug(f"Link found: {pretty_url}")
 
         if self.link_count < self.max_links:
             self.link_count += 1
-            logger.debug(Fore.GREEN + f"Links crawled: {self.link_count}")
+            logger.debug(f"Links crawled: {self.link_count}")
 
     def start(self) -> Dict[str, Dict[str, List[str]]]:
         """
@@ -153,5 +152,5 @@ class Spider:
 
         if self.save_to_file:
             self.save_results()
-        logger.debug("%s%sExiting....", Style.BRIGHT, Fore.MAGENTA)
+        logger.debug("Exiting....")
         return self.crawl_result

--- a/src/tiny_web_crawler/core/spider.py
+++ b/src/tiny_web_crawler/core/spider.py
@@ -81,14 +81,14 @@ class Spider:
             url (str): The URL to crawl.
         """
         if not is_valid_url(url):
-            logger.debug(f"Invalid url to crawl: {url}")
+            logger.debug("Invalid url to crawl: %s", url)
             return
 
         if url in self.crawl_result:
-            logger.debug(f"URL already crawled: {url}")
+            logger.debug("URL already crawled: %s", url)
             return
 
-        logger.debug(f"Crawling: {url}")
+        logger.debug("Crawling: %s", url)
         soup = fetch_url(url)
         if not soup:
             return
@@ -102,7 +102,7 @@ class Spider:
         for link in links:
             pretty_url = format_url(link['href'].lstrip(), url, self.scheme)
             if not is_valid_url(pretty_url):
-                logger.debug(f"Invalid url: {pretty_url}")
+                logger.debug("Invalid url: %s", pretty_url)
                 continue
 
             if pretty_url in self.crawl_result[url]['urls']:
@@ -110,24 +110,24 @@ class Spider:
 
             if self.url_regex:
                 if not re.compile(self.url_regex).match(pretty_url):
-                    logger.debug(f"Skipping: URL didn't match regex: {pretty_url}")
+                    logger.debug("Skipping: URL didn't match regex: %s", pretty_url)
                     continue
 
             if self.internal_links_only and self.root_netloc != urllib.parse.urlparse(pretty_url).netloc:
-                logger.debug(f"Skipping: External link: {pretty_url}")
+                logger.debug("Skipping: External link: %s", pretty_url)
                 continue
 
             if self.external_links_only and self.root_netloc == urllib.parse.urlparse(pretty_url).netloc:
-                logger.debug(f"Skipping: Internal link: {pretty_url}")
+                logger.debug("Skipping: Internal link: %s", pretty_url)
                 continue
 
             self.crawl_result[url]['urls'].append(pretty_url)
             self.crawl_set.add(pretty_url)
-            logger.debug(f"Link found: {pretty_url}")
+            logger.debug("Link found: %s", pretty_url)
 
         if self.link_count < self.max_links:
             self.link_count += 1
-            logger.debug(f"Links crawled: {self.link_count}")
+            logger.debug("Links crawled: %s", self.link_count)
 
     def start(self) -> Dict[str, Dict[str, List[str]]]:
         """

--- a/src/tiny_web_crawler/logging.py
+++ b/src/tiny_web_crawler/logging.py
@@ -1,10 +1,11 @@
 import logging
 from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL, FATAL, NOTSET # pylint: disable=unused-import
 
-LOGGER_NAME: str = "tiny-web-crawler-logger"
+LOGGER_NAME: str = "tiny-web-crawler"
 DEFAULT_LOG_LEVEL = INFO
 
-logging.getLogger().setLevel(level=DEFAULT_LOG_LEVEL)
+logging.basicConfig(level=DEBUG)
+logging.getLogger(LOGGER_NAME).setLevel(level=DEFAULT_LOG_LEVEL)
 
 def get_logger() -> logging.Logger:
     return logging.getLogger(LOGGER_NAME)

--- a/src/tiny_web_crawler/logging.py
+++ b/src/tiny_web_crawler/logging.py
@@ -1,14 +1,42 @@
 import logging
 from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL, FATAL, NOTSET # pylint: disable=unused-import
 
-LOGGER_NAME: str = "tiny-web-crawler"
-DEFAULT_LOG_LEVEL = INFO
+from colorama import Fore
 
-logging.basicConfig(level=DEBUG)
-logging.getLogger(LOGGER_NAME).setLevel(level=DEFAULT_LOG_LEVEL)
+LOGGER_NAME: str = "tiny-web-crawler"
+DEFAULT_LOG_LEVEL: int = INFO
+
+class ColorFormatter(logging.Formatter):
+
+    message_format: str = "%(levelname)s %(message)s"
+
+    FORMATS = {
+        logging.DEBUG: Fore.LIGHTBLUE_EX + message_format + Fore.RESET,
+        logging.INFO: Fore.BLUE + message_format + Fore.RESET,
+        logging.WARNING: Fore.YELLOW + message_format + Fore.RESET,
+        logging.ERROR: Fore.RED + message_format + Fore.RESET,
+        logging.CRITICAL: Fore.RED + message_format + Fore.RESET
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)
+
 
 def get_logger() -> logging.Logger:
     return logging.getLogger(LOGGER_NAME)
 
+
 def set_logging_level(level:int) -> None:
     get_logger().setLevel(level=level)
+
+
+get_logger().setLevel(level=DEFAULT_LOG_LEVEL)
+
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.DEBUG)
+
+console_handler.setFormatter(ColorFormatter())
+
+get_logger().addHandler(console_handler)

--- a/src/tiny_web_crawler/logging.py
+++ b/src/tiny_web_crawler/logging.py
@@ -1,0 +1,13 @@
+import logging
+from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL, FATAL, NOTSET # pylint: disable=unused-import
+
+LOGGER_NAME: str = "tiny-web-crawler-logger"
+DEFAULT_LOG_LEVEL = INFO
+
+logging.basicConfig(level=DEFAULT_LOG_LEVEL)
+
+def get_logger() -> logging.Logger:
+    return logging.getLogger(LOGGER_NAME)
+
+def set_logging_level(level:int) -> None:
+    get_logger().setLevel(level=level)

--- a/src/tiny_web_crawler/logging.py
+++ b/src/tiny_web_crawler/logging.py
@@ -4,7 +4,7 @@ from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL, FATAL, NOTSET # pylin
 LOGGER_NAME: str = "tiny-web-crawler-logger"
 DEFAULT_LOG_LEVEL = INFO
 
-logging.basicConfig(level=DEFAULT_LOG_LEVEL)
+logging.getLogger().setLevel(level=DEFAULT_LOG_LEVEL)
 
 def get_logger() -> logging.Logger:
     return logging.getLogger(LOGGER_NAME)

--- a/src/tiny_web_crawler/networking/fetcher.py
+++ b/src/tiny_web_crawler/networking/fetcher.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 import requests
 from bs4 import BeautifulSoup
-from colorama import Fore
 
 from tiny_web_crawler.logging import get_logger
 
@@ -15,11 +14,11 @@ def fetch_url(url: str) -> Optional[BeautifulSoup]:
         data = response.text
         return BeautifulSoup(data, 'lxml')
     except requests.exceptions.HTTPError as http_err:
-        logger.error(Fore.RED + f"HTTP error occurred: {http_err}")
+        logger.error(f"HTTP error occurred: {http_err}")
     except requests.exceptions.ConnectionError as conn_err:
-        logger.error(Fore.RED + f"Connection error occurred: {conn_err}")
+        logger.error(f"Connection error occurred: {conn_err}")
     except requests.exceptions.Timeout as timeout_err:
-        logger.error(Fore.RED + f"Timeout error occurred: {timeout_err}")
+        logger.error(f"Timeout error occurred: {timeout_err}")
     except requests.exceptions.RequestException as req_err:
-        logger.error(Fore.RED + f"Request error occurred: {req_err}")
+        logger.error(f"Request error occurred: {req_err}")
     return None

--- a/src/tiny_web_crawler/networking/fetcher.py
+++ b/src/tiny_web_crawler/networking/fetcher.py
@@ -14,11 +14,11 @@ def fetch_url(url: str) -> Optional[BeautifulSoup]:
         data = response.text
         return BeautifulSoup(data, 'lxml')
     except requests.exceptions.HTTPError as http_err:
-        logger.error(f"HTTP error occurred: {http_err}")
+        logger.error("HTTP error occurred: %s", http_err)
     except requests.exceptions.ConnectionError as conn_err:
-        logger.error(f"Connection error occurred: {conn_err}")
+        logger.error("Connection error occurred: %s", conn_err)
     except requests.exceptions.Timeout as timeout_err:
-        logger.error(f"Timeout error occurred: {timeout_err}")
+        logger.error("Timeout error occurred: %s", timeout_err)
     except requests.exceptions.RequestException as req_err:
-        logger.error(f"Request error occurred: {req_err}")
+        logger.error("Request error occurred: %s", req_err)
     return None

--- a/src/tiny_web_crawler/networking/fetcher.py
+++ b/src/tiny_web_crawler/networking/fetcher.py
@@ -4,6 +4,9 @@ import requests
 from bs4 import BeautifulSoup
 from colorama import Fore
 
+from tiny_web_crawler.logging import get_logger
+
+logger = get_logger()
 
 def fetch_url(url: str) -> Optional[BeautifulSoup]:
     try:
@@ -12,11 +15,11 @@ def fetch_url(url: str) -> Optional[BeautifulSoup]:
         data = response.text
         return BeautifulSoup(data, 'lxml')
     except requests.exceptions.HTTPError as http_err:
-        print(Fore.RED + f"HTTP error occurred: {http_err}")
+        logger.error(Fore.RED + f"HTTP error occurred: {http_err}")
     except requests.exceptions.ConnectionError as conn_err:
-        print(Fore.RED + f"Connection error occurred: {conn_err}")
+        logger.error(Fore.RED + f"Connection error occurred: {conn_err}")
     except requests.exceptions.Timeout as timeout_err:
-        print(Fore.RED + f"Timeout error occurred: {timeout_err}")
+        logger.error(Fore.RED + f"Timeout error occurred: {timeout_err}")
     except requests.exceptions.RequestException as req_err:
-        print(Fore.RED + f"Request error occurred: {req_err}")
+        logger.error(Fore.RED + f"Request error occurred: {req_err}")
     return None

--- a/tests/logging/test_logging.py
+++ b/tests/logging/test_logging.py
@@ -1,0 +1,35 @@
+import logging
+
+from tiny_web_crawler.core.spider import Spider
+from tiny_web_crawler.logging import get_logger, set_logging_level, DEBUG, INFO, ERROR, LOGGER_NAME
+
+def test_get_logger() -> None:
+    logger = get_logger()
+
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == LOGGER_NAME
+
+
+def test_set_logging_level(caplog) -> None: # type: ignore
+    logger = get_logger()
+
+    set_logging_level(ERROR)
+
+    logger.info("123")
+    logger.error("456")
+
+    assert logger.getEffectiveLevel() == ERROR
+    assert "123" not in caplog.text
+    assert "456" in caplog.text
+
+
+def test_verbose_logging_level() -> None:
+    logger = get_logger()
+
+    spider = Spider("http://example.com", verbose=True) # pylint: disable=unused-variable
+
+    assert logger.getEffectiveLevel() == DEBUG
+
+    spider = Spider("http://example.com", verbose=False) # pylint: disable=unused-variable
+
+    assert logger.getEffectiveLevel() == INFO


### PR DESCRIPTION
Closes #38 

**Changes**
- Added the `logging` submodule in `logging.py`;
  - This just has two functions, a `get_logger` function that returns the logger object and a `set_logging_level` function that changes the log level of the logger;
  - Since the logic for this was so simple I removed the `logging` folder with `__init__.py` inside and just created a `logging.py` file, but let me know if I should change that;
- Changed the `verbose_print`'s and `print`'s to use the logger instead (In the `Spider` class and in `fetch_url`);
- Removed the `verbose_print` method of `Spider`. Instead, the log level of the logger is set according to the verbose argument: `True -> DEBUG` `False -> INFO`;
- Replaced `capsys` with `caplog` in the tests so that they work with the log output instead of stdout;
- Added test cases for the logging feature;