### PR TITLE
Retry mechanism for transient errors

### DIFF
--- a/src/tiny_web_crawler/core/spider.py
+++ b/src/tiny_web_crawler/core/spider.py
@@ -85,7 +85,7 @@ class Spider:
             return
 
         logger.debug("Crawling: %s", url)
-        soup = fetch_url(url)
+        soup = fetch_url(url, retries=self.settings.max_retry_attempts)
         if not soup:
             return
 

--- a/src/tiny_web_crawler/core/spider_settings.py
+++ b/src/tiny_web_crawler/core/spider_settings.py
@@ -40,6 +40,7 @@ class CrawlSettings:
     internal_links_only: bool = False
     external_links_only: bool = False
     respect_robots_txt: bool = True
+    max_retry_attempts: int = 5
 
 @dataclass
 class SpiderSettings(GeneralSettings, CrawlSettings):

--- a/src/tiny_web_crawler/networking/fetcher.py
+++ b/src/tiny_web_crawler/networking/fetcher.py
@@ -7,13 +7,12 @@ from bs4 import BeautifulSoup
 from tiny_web_crawler.logging import get_logger
 
 MAX_RETRIES = 5
+TRANSIENT_ERRORS = [408, 502, 503, 504]
 
 logger = get_logger()
 
 def is_transient_error(status_code: int) -> bool:
-    transient_errors = [408, 502, 503, 504]
-
-    return status_code in transient_errors
+    return status_code in TRANSIENT_ERRORS
 
 def fetch_url(url: str, retries: int = MAX_RETRIES) -> Optional[BeautifulSoup]:
     try:

--- a/src/tiny_web_crawler/networking/fetcher.py
+++ b/src/tiny_web_crawler/networking/fetcher.py
@@ -6,7 +6,6 @@ from bs4 import BeautifulSoup
 
 from tiny_web_crawler.logging import get_logger
 
-MAX_RETRIES = 5
 TRANSIENT_ERRORS = [408, 502, 503, 504]
 
 logger = get_logger()
@@ -14,17 +13,17 @@ logger = get_logger()
 def is_transient_error(status_code: int) -> bool:
     return status_code in TRANSIENT_ERRORS
 
-def fetch_url(url: str, retries: int = MAX_RETRIES) -> Optional[BeautifulSoup]:
+def fetch_url(url: str, retries: int, attempts: int = 0) -> Optional[BeautifulSoup]:
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         data = response.text
         return BeautifulSoup(data, 'lxml')
     except requests.exceptions.HTTPError as http_err:
-        if response.status_code and is_transient_error(response.status_code) and retries > 1:
+        if response.status_code and is_transient_error(response.status_code) and retries > 0:
             logger.error("Transient HTTP error occurred: %s. Retrying...", http_err)
-            time.sleep( 1*(MAX_RETRIES-retries+1) )
-            return fetch_url( url, retries-1 )
+            time.sleep( attempts+1 )
+            return fetch_url( url, retries-1 , attempts+1)
 
         logger.error("HTTP error occurred: %s", http_err)
         return None

--- a/src/tiny_web_crawler/networking/fetcher.py
+++ b/src/tiny_web_crawler/networking/fetcher.py
@@ -1,20 +1,34 @@
 from typing import Optional
+import time
 
 import requests
 from bs4 import BeautifulSoup
 
 from tiny_web_crawler.logging import get_logger
 
+MAX_RETRIES = 5
+
 logger = get_logger()
 
-def fetch_url(url: str) -> Optional[BeautifulSoup]:
+def is_transient_error(status_code: int) -> bool:
+    transient_errors = [408, 502, 503, 504]
+
+    return status_code in transient_errors
+
+def fetch_url(url: str, retries: int = MAX_RETRIES) -> Optional[BeautifulSoup]:
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         data = response.text
         return BeautifulSoup(data, 'lxml')
     except requests.exceptions.HTTPError as http_err:
+        if response.status_code and is_transient_error(response.status_code) and retries > 1:
+            logger.error("Transient HTTP error occurred: %s. Retrying...", http_err)
+            time.sleep( 1*(MAX_RETRIES-retries+1) )
+            return fetch_url( url, retries-1 )
+
         logger.error("HTTP error occurred: %s", http_err)
+        return None
     except requests.exceptions.ConnectionError as conn_err:
         logger.error("Connection error occurred: %s", conn_err)
     except requests.exceptions.Timeout as timeout_err:

--- a/tests/networking/test_fetcher.py
+++ b/tests/networking/test_fetcher.py
@@ -34,7 +34,7 @@ def test_fetch_url_connection_error(caplog) -> None: # type: ignore
 
 @responses.activate
 def test_fetch_url_http_error(caplog) -> None: # type: ignore
-    error_codes = [403, 404, 408]
+    error_codes = [403, 404, 412]
 
     for error_code in error_codes:
         setup_mock_response(


### PR DESCRIPTION
Closes #39 

**Changes**
- Added a `is_transient_error` function inside `fetcher.py`;
  - I hardcoded the list of transient errors as `[408, 502, 503, 504]` since they're the most common ones, but let me know if I should add/remove any;
- Modified `fetch_url` to retry fetching the url when it encounters a transient error until `retries` reaches 0;
- Added tests to test the retry feature both directly through the `fetch_url` function and in the `crawl` method;
- Added a `max_retry_attempts` option to `CrawlSettings`;

Ps.: The wait times for each consecutive retry attempt are just `1, 2 ,3, ...` seconds. Let me know if that's ok.